### PR TITLE
Secure access validation and restrict kiosk

### DIFF
--- a/app/api/debug/cards/route.ts
+++ b/app/api/debug/cards/route.ts
@@ -1,7 +1,17 @@
 import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createServerClient } from '@supabase/ssr'
+
 import { getServiceRoleClient, getServiceRoleConfig } from '@/lib/supabase/service-role'
+import { userHasRole } from '@/lib/auth/roles'
 
 export async function GET() {
+  const enabled = process.env.ENABLE_DEBUG_ENDPOINT === 'true'
+
+  if (!enabled) {
+    return NextResponse.json({ ok: false, error: 'not_found' }, { status: 404 })
+  }
+
   try {
     const config = getServiceRoleConfig()
 
@@ -17,28 +27,67 @@ export async function GET() {
       )
     }
 
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    if (!anonKey) {
+      console.error('DEBUG - falta NEXT_PUBLIC_SUPABASE_ANON_KEY')
+      return NextResponse.json(
+        {
+          ok: false,
+          error: 'missing_supabase_config',
+          missing: ['NEXT_PUBLIC_SUPABASE_URL', 'NEXT_PUBLIC_SUPABASE_ANON_KEY'],
+        },
+        { status: 503 },
+      )
+    }
+
+    const cookieStore = cookies()
+    const authClient = createServerClient(config.url, anonKey, {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        set(name: string, value: string, options) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name: string, options) {
+          cookieStore.set({ name, value: '', ...options })
+        },
+      },
+    })
+
+    const {
+      data: { user },
+      error: authError,
+    } = await authClient.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 })
+    }
+
+    if (!userHasRole(user, 'admin')) {
+      return NextResponse.json({ ok: false, error: 'forbidden' }, { status: 403 })
+    }
+
     const supabase = getServiceRoleClient(config)
-    console.log("DEBUG - Supabase URL:", process.env.NEXT_PUBLIC_SUPABASE_URL)
 
     const { data, error } = await supabase
       .from('cards')
-      .select('uid, active, athlete_id, created_at')
+      .select('uid, active, created_at')
       .order('created_at', { ascending: false })
       .limit(10)
 
     if (error) {
-      console.error("DEBUG - error al consultar cards:", error)
-      return NextResponse.json({ ok: false, error })
+      console.error('DEBUG - error al consultar cards:', error)
+      return NextResponse.json({ ok: false, error: 'query_failed' }, { status: 500 })
     }
 
     return NextResponse.json({
       ok: true,
-      supabase_url: process.env.NEXT_PUBLIC_SUPABASE_URL,
       count: data?.length || 0,
-      cards: data
+      cards: data,
     })
   } catch (err) {
-    console.error("DEBUG - error general en /api/debug/cards:", err)
-    return NextResponse.json({ ok: false, error: String(err) }, { status: 500 })
+    console.error('DEBUG - error general en /api/debug/cards:', err)
+    return NextResponse.json({ ok: false, error: 'unexpected_error' }, { status: 500 })
   }
 }

--- a/app/kiosk/page.tsx
+++ b/app/kiosk/page.tsx
@@ -2,10 +2,8 @@
 import { useEffect, useRef, useState } from 'react'
 
 type AccessResult = {
-  name: string
   uid: string
-  membership?: string
-  endDate?: string
+  membershipEndsAt?: string | null
   status: 'allowed' | 'expired' | 'unknown_card'
 }
 
@@ -24,7 +22,7 @@ export default function KioskPage() {
   const [message, setMessage] = useState<string>('Acerca la tarjeta...')
   const [lastUID, setLastUID] = useState<string>('')   
   const [lastEndDate, setLastEndDate] = useState<string>('')   
-  const [history, setHistory] = useState<AccessResult[]>([]) 
+  const [history, setHistory] = useState<AccessResult[]>([])
   const bufferRef = useRef<string>('') 
   const timeoutRef = useRef<any>(null)  
 
@@ -79,24 +77,20 @@ export default function KioskPage() {
 
       if (data.ok && data.result === 'allowed') {
         setStatus('ok')
-        setMessage(`✅ ACCESO PERMITIDO\n${data.athlete.name}`)
+        setMessage('✅ ACCESO PERMITIDO')
         setLastEndDate(data.membership?.end_date || '')
         addToHistory({
-          name: data.athlete.name,
           uid: data.uid,
-          membership: 'Vigente',
-          endDate: data.membership?.end_date,
+          membershipEndsAt: data.membership?.end_date,
           status: 'allowed'
         })
       } else if (data.result === 'expired') {
         setStatus('fail')
-        setMessage(`⚠️ MEMBRESÍA EXPIRADA\n${data.athlete?.name || ''}`)
+        setMessage('⚠️ MEMBRESÍA EXPIRADA')
         setLastEndDate(data.membership?.end_date || '')
         addToHistory({
-          name: data.athlete?.name || 'Desconocido',
           uid: data.uid,
-          membership: 'Expirada',
-          endDate: data.membership?.end_date,
+          membershipEndsAt: data.membership?.end_date,
           status: 'expired'
         })
       } else {
@@ -104,9 +98,7 @@ export default function KioskPage() {
         setMessage(`❌ TARJETA DESCONOCIDA\nUID: ${data.uid}`)
         setLastEndDate('')
         addToHistory({
-          name: 'Desconocido',
           uid: data.uid,
-          membership: 'N/A',
           status: 'unknown_card'
         })
       }
@@ -173,12 +165,11 @@ export default function KioskPage() {
                 h.status === 'allowed' ? 'bg-green-100' : 'bg-red-100'
               ].join(' ')}
             >
-              <p className="font-semibold">{h.name}</p>
-              <p className="text-sm text-gray-700">Tarjeta: {h.uid}</p>
-              <p className="text-sm text-gray-700">Membresía: {h.membership}</p>
-              {h.endDate && (
+              <p className="font-semibold">UID: {h.uid}</p>
+              <p className="text-sm text-gray-700 capitalize">Estado: {h.status.replace('_', ' ')}</p>
+              {h.membershipEndsAt && (
                 <p className="text-sm text-gray-500">
-                  Vence: {formatDate(h.endDate)}
+                  Vence: {formatDate(h.membershipEndsAt)}
                 </p>
               )}
             </div>

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -1,0 +1,142 @@
+export type RoleLike = string | string[] | undefined | null
+
+type RoleSource = Record<string, unknown> | null | undefined
+
+const ROLE_KEY_PATTERN = /role|permission|claim/i
+
+function addRole(collected: Set<string>, role: string) {
+  const normalized = role.trim().toLowerCase()
+  if (normalized.length > 0) {
+    collected.add(normalized)
+  }
+}
+
+function deriveRoleFromKey(key: string): string {
+  const normalized = key.trim().toLowerCase()
+  const parts = normalized.split(/[_\-\s]+/).filter(Boolean)
+  const filtered = parts.filter((part) => !ROLE_KEY_PATTERN.test(part))
+
+  if (filtered.length > 0) {
+    return filtered[filtered.length - 1]
+  }
+
+  const stripped = normalized.replace(ROLE_KEY_PATTERN, '').replace(/[_\-\s]+/g, '')
+  return stripped || normalized
+}
+
+function parsePotentialJson(value: string): unknown {
+  try {
+    return JSON.parse(value)
+  } catch (_err) {
+    return undefined
+  }
+}
+
+function extractFromValue(
+  collected: Set<string>,
+  value: unknown,
+  contextKey?: string,
+) {
+  if (value == null) {
+    return
+  }
+
+  if (typeof value === 'string') {
+    if (!contextKey || !ROLE_KEY_PATTERN.test(contextKey) || value.trim().length === 0) {
+      return
+    }
+
+    const trimmed = value.trim()
+    const parsed = parsePotentialJson(trimmed)
+
+    if (parsed !== undefined) {
+      extractFromValue(collected, parsed, contextKey)
+      return
+    }
+
+    const byComma = trimmed
+      .split(/[,;]/)
+      .map((part) => part.trim())
+      .filter(Boolean)
+
+    if (byComma.length > 1) {
+      byComma.forEach((role) => addRole(collected, role))
+      return
+    }
+
+    const byWhitespace = trimmed
+      .split(/\s+/)
+      .map((part) => part.trim())
+      .filter(Boolean)
+
+    if (byWhitespace.length > 1) {
+      byWhitespace.forEach((role) => addRole(collected, role))
+      return
+    }
+
+    addRole(collected, trimmed)
+    return
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => extractFromValue(collected, item, contextKey))
+    return
+  }
+
+  if (typeof value === 'object') {
+    Object.entries(value as Record<string, unknown>).forEach(([key, nested]) => {
+      if (typeof nested === 'boolean') {
+        if (nested && (ROLE_KEY_PATTERN.test(key) || (contextKey && ROLE_KEY_PATTERN.test(contextKey)))) {
+          addRole(collected, deriveRoleFromKey(key))
+        }
+        return
+      }
+
+      const nextContext = ROLE_KEY_PATTERN.test(key) ? key : contextKey
+      extractFromValue(collected, nested, nextContext)
+    })
+  }
+}
+
+function collectRoles(source: RoleSource): Set<string> {
+  const collected = new Set<string>()
+
+  if (!source) {
+    return collected
+  }
+
+  const record = source as Record<string, unknown>
+  extractFromValue(collected, record)
+
+  return collected
+}
+
+export function getUserRoles(
+  user: { app_metadata?: Record<string, unknown>; user_metadata?: Record<string, unknown> } | null | undefined,
+): Set<string> {
+  const roles = new Set<string>()
+
+  if (!user) {
+    return roles
+  }
+
+  const appRoles = collectRoles(user.app_metadata)
+  const userRoles = collectRoles(user.user_metadata)
+
+  appRoles.forEach((role) => roles.add(role))
+  userRoles.forEach((role) => roles.add(role))
+
+  return roles
+}
+
+export function userHasRole(
+  user: { app_metadata?: Record<string, unknown>; user_metadata?: Record<string, unknown> } | null | undefined,
+  required: string | string[],
+): boolean {
+  const roles = getUserRoles(user)
+  const requiredRoles = Array.isArray(required) ? required : [required]
+
+  return requiredRoles
+    .map((role) => role.toLowerCase())
+    .some((role) => roles.has(role))
+}


### PR DESCRIPTION
## Summary
- require an authenticated Supabase session with admin or kiosk role before allowing `/api/access/validate` to run and trim the response to only include status metadata
- guard `/api/debug/cards` behind an explicit feature flag plus admin session checks so it is disabled by default in production
- restrict the kiosk UI behind middleware and update the client to stop showing athlete names or membership details
- broaden the shared role normalization helper so multi-format metadata for admin and kiosk sessions is consistently honored across middleware and APIs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4b59659e4832eb52a4d7b7238b1b0