### PR TITLE
Add admin reports section with sample CSV downloads

### DIFF
--- a/app/(site)/admin/page.tsx
+++ b/app/(site)/admin/page.tsx
@@ -46,6 +46,11 @@ export default function AdminHome() {
           title="Rutinas"
           subtitle="Subir y administrar PDFs públicos"
         />
+        <Tile
+          href="/admin/reports"
+          title="Reportes"
+          subtitle="Descarga de accesos, membresías y más"
+        />
       </div>
     </main>
   )

--- a/app/(site)/admin/reports/page.tsx
+++ b/app/(site)/admin/reports/page.tsx
@@ -1,0 +1,107 @@
+import Link from 'next/link'
+
+type ReportAction = {
+  href: string
+  label: string
+  description?: string
+}
+
+type ReportCardProps = {
+  title: string
+  summary: string
+  actions: ReportAction[]
+}
+
+function ReportCard({ title, summary, actions }: ReportCardProps) {
+  return (
+    <section className="rounded-2xl border bg-white p-6 shadow-sm">
+      <header className="mb-4">
+        <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+        <p className="mt-1 text-sm text-gray-600">{summary}</p>
+      </header>
+      <div className="flex flex-wrap gap-3">
+        {actions.map((action) => (
+          <Link
+            key={action.href + action.label}
+            href={action.href}
+            prefetch={false}
+            download
+            className="inline-flex items-center gap-2 rounded-lg border border-blue-100 bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700 transition hover:border-blue-200 hover:bg-blue-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2"
+          >
+            <span>{action.label}</span>
+            {action.description && (
+              <span className="text-xs font-normal text-blue-500">
+                {action.description}
+              </span>
+            )}
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+const reportGroups: ReportCardProps[] = [
+  {
+    title: 'Accesos por tarjeta',
+    summary:
+      'Descarga los registros históricos de accesos con validación OK o NOK para revisar actividades inusuales.',
+    actions: [
+      {
+        href: '/api/admin/reports/access?status=ok',
+        label: 'Descargar accesos OK',
+        description: 'CSV',
+      },
+      {
+        href: '/api/admin/reports/access?status=nok',
+        label: 'Descargar accesos NOK',
+        description: 'CSV',
+      },
+    ],
+  },
+  {
+    title: 'Actualizaciones de membresía',
+    summary:
+      'Listado de renovaciones, degradaciones y suspensiones para conciliar con facturación y área comercial.',
+    actions: [
+      {
+        href: '/api/admin/reports/memberships',
+        label: 'Descargar movimientos de membresía',
+        description: 'CSV',
+      },
+    ],
+  },
+  {
+    title: 'Reportes adicionales',
+    summary:
+      'Propuesta inicial con métricas clave de actividad. Puedes ampliar esta sección con nuevos reportes.',
+    actions: [
+      {
+        href: '/api/admin/reports/summary',
+        label: 'Descargar resumen mensual',
+        description: 'CSV',
+      },
+    ],
+  },
+]
+
+export default function ReportsPage() {
+  return (
+    <main className="space-y-6">
+      <header className="text-center">
+        <h1 className="text-3xl font-bold text-gray-900">Reportes</h1>
+        <p className="mx-auto mt-2 max-w-3xl text-sm text-gray-600">
+          Explora opciones preliminares de reportes para el panel administrativo. Puedes descargar los archivos CSV con datos
+          ficticios a modo de ejemplo y utilizarlos como base para futuras integraciones con la base de datos.
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {reportGroups.map((group) => (
+          <ReportCard key={group.title} {...group} />
+        ))}
+      </div>
+    </main>
+  )
+}
+

--- a/app/api/admin/reports/access/route.ts
+++ b/app/api/admin/reports/access/route.ts
@@ -1,0 +1,73 @@
+import type { NextRequest } from 'next/server'
+
+type AccessStatus = 'ok' | 'nok'
+
+const dataByStatus: Record<AccessStatus, Array<Record<string, string>>> = {
+  ok: [
+    {
+      fecha: '2024-06-01T06:05:11Z',
+      socio: 'María González',
+      membresia: 'Full Access',
+      tarjeta: 'A1B2C3',
+      estado: 'OK',
+    },
+    {
+      fecha: '2024-06-01T07:12:43Z',
+      socio: 'Juan Pérez',
+      membresia: 'Morning Club',
+      tarjeta: 'D4E5F6',
+      estado: 'OK',
+    },
+    {
+      fecha: '2024-06-01T08:55:09Z',
+      socio: 'Camila Rojas',
+      membresia: 'Weekend Pass',
+      tarjeta: 'G7H8I9',
+      estado: 'OK',
+    },
+  ],
+  nok: [
+    {
+      fecha: '2024-06-01T06:45:02Z',
+      socio: 'Luis Muñoz',
+      membresia: 'Full Access',
+      tarjeta: 'J1K2L3',
+      estado: 'NOK',
+    },
+    {
+      fecha: '2024-06-01T09:31:27Z',
+      socio: 'Daniela Silva',
+      membresia: 'Corporate',
+      tarjeta: 'M4N5O6',
+      estado: 'NOK',
+    },
+  ],
+}
+
+function toCsv(rows: Array<Record<string, string>>) {
+  if (rows.length === 0) {
+    return 'mensaje\nNo se encontraron registros para los filtros seleccionados.'
+  }
+
+  const header = Object.keys(rows[0])
+  const csvRows = rows.map((row) => header.map((key) => row[key] ?? '').join(','))
+
+  return [header.join(','), ...csvRows].join('\n')
+}
+
+export async function GET(request: NextRequest) {
+  const statusParam = request.nextUrl.searchParams.get('status') ?? 'ok'
+  const status = statusParam === 'nok' ? 'nok' : 'ok'
+
+  const csv = toCsv(dataByStatus[status])
+  const fileName = `reporte_accesos_${status}.csv`
+
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${fileName}"`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+

--- a/app/api/admin/reports/memberships/route.ts
+++ b/app/api/admin/reports/memberships/route.ts
@@ -1,0 +1,50 @@
+const membershipEvents = [
+  {
+    fecha: '2024-05-28',
+    socio: 'María González',
+    movimiento: 'Renovación',
+    plan_anterior: 'Full Access',
+    plan_nuevo: 'Full Access',
+    ejecutado_por: 'Backend automático',
+  },
+  {
+    fecha: '2024-05-29',
+    socio: 'Juan Pérez',
+    movimiento: 'Upgrade',
+    plan_anterior: 'Morning Club',
+    plan_nuevo: 'Full Access',
+    ejecutado_por: 'Admin - Carla',
+  },
+  {
+    fecha: '2024-05-31',
+    socio: 'Daniela Silva',
+    movimiento: 'Suspensión',
+    plan_anterior: 'Corporate',
+    plan_nuevo: 'Corporate (Suspendida)',
+    ejecutado_por: 'Admin - Rodrigo',
+  },
+]
+
+function toCsv(rows: Array<Record<string, string>>) {
+  if (rows.length === 0) {
+    return 'mensaje\nNo se encontraron registros para el período seleccionado.'
+  }
+
+  const header = Object.keys(rows[0])
+  const csvRows = rows.map((row) => header.map((key) => row[key] ?? '').join(','))
+
+  return [header.join(','), ...csvRows].join('\n')
+}
+
+export async function GET() {
+  const csv = toCsv(membershipEvents)
+
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="reporte_membresias.csv"',
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+

--- a/app/api/admin/reports/summary/route.ts
+++ b/app/api/admin/reports/summary/route.ts
@@ -1,0 +1,42 @@
+const summaryRows = [
+  {
+    periodo: '2024-05',
+    accesos_ok: '1240',
+    accesos_nok: '37',
+    nuevos_socios: '58',
+    membresias_suspendidas: '12',
+    ingresos_estimados: '14500000',
+  },
+  {
+    periodo: '2024-04',
+    accesos_ok: '1187',
+    accesos_nok: '45',
+    nuevos_socios: '63',
+    membresias_suspendidas: '9',
+    ingresos_estimados: '13850000',
+  },
+]
+
+function toCsv(rows: Array<Record<string, string>>) {
+  if (rows.length === 0) {
+    return 'mensaje\nNo hay datos disponibles para el resumen solicitado.'
+  }
+
+  const header = Object.keys(rows[0])
+  const csvRows = rows.map((row) => header.map((key) => row[key] ?? '').join(','))
+
+  return [header.join(','), ...csvRows].join('\n')
+}
+
+export async function GET() {
+  const csv = toCsv(summaryRows)
+
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="reporte_resumen_mensual.csv"',
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+


### PR DESCRIPTION
## Summary
- add a new Reportes tile to the admin dashboard that leads to a dedicated reports hub
- create a reports page with proposed download options for access logs, membership updates, and future summaries
- expose sample CSV download endpoints for access validations, membership events, and monthly summaries to support the UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4c15fe54c832e8d1b86d92173cf2b