### PR TITLE
Ensure Chile timezone is respected across reports and UI

### DIFF
--- a/app/(site)/admin/athletes/[id]/page.tsx
+++ b/app/(site)/admin/athletes/[id]/page.tsx
@@ -5,6 +5,7 @@ export const dynamic = 'force-dynamic'
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
+import { formatChileDateTime, fromChileDateOnly, toChileDateString } from '@/lib/chileTime'
 
 type Athlete = {
   id: string
@@ -26,7 +27,7 @@ type AccessLog = {
 }
 
 function fmtDate(d: Date) {
-  return d.toISOString().slice(0, 10)
+  return toChileDateString(d)
 }
 function addMonths(date: Date, months: number) {
   const d = new Date(date)
@@ -110,7 +111,7 @@ export default function AthleteEditPage() {
     setCurrentEnd((mem as any)?.end_date ?? '')
     setMemPlan(planFromMem)
     setMemStart(today)
-    const base = new Date(today)
+    const base = fromChileDateOnly(today)
     setMemEnd(fmtDate(planFromMem === 'Anual' ? addMonths(base, 12) : addMonths(base, 1)))
 
     // 4) Historial de accesos (últimos 20)
@@ -134,7 +135,7 @@ export default function AthleteEditPage() {
   // Recalcular fin al cambiar plan o start (para la NUEVA membresía)
   useEffect(() => {
     if (!memStart) return
-    const base = new Date(memStart)
+    const base = fromChileDateOnly(memStart)
     const end = memPlan === 'Anual' ? addMonths(base, 12) : addMonths(base, 1)
     setMemEnd(fmtDate(end))
   }, [memPlan, memStart])
@@ -339,7 +340,10 @@ export default function AthleteEditPage() {
 
         {/* Actual vigente (solo lectura) */}
         <div className="text-sm text-gray-700">
-          <div>Vigente actual: {currentStart ? `${new Date(currentStart).toLocaleDateString()} → ${new Date(currentEnd).toLocaleDateString()}` : '—'}</div>
+          <div>
+            Vigente actual:{' '}
+            {currentStart ? `${toChileDateString(currentStart)} → ${toChileDateString(currentEnd)}` : '—'}
+          </div>
         </div>
 
         {/* Nueva membresía */}
@@ -381,7 +385,7 @@ export default function AthleteEditPage() {
           <button
             disabled={busy}
             onClick={() => {
-              const base = memStart ? new Date(memStart) : new Date()
+              const base = memStart ? fromChileDateOnly(memStart) : new Date()
               const end = memPlan === 'Anual' ? addMonths(base, 12) : addMonths(base, 1)
               setMemEnd(fmtDate(end))
             }}
@@ -411,7 +415,7 @@ export default function AthleteEditPage() {
               <tbody>
                 {access.map((l) => (
                   <tr key={l.id} className="border-t">
-                    <td className="px-3 py-2">{new Date(l.ts).toLocaleString()}</td>
+                    <td className="px-3 py-2">{formatChileDateTime(l.ts)}</td>
                     <td className="px-3 py-2">{l.result}</td>
                     <td className="px-3 py-2">{l.card_uid ?? '—'}</td>
                     <td className="px-3 py-2">{l.note ?? '—'}</td>

--- a/app/(site)/admin/athletes/new/page.tsx
+++ b/app/(site)/admin/athletes/new/page.tsx
@@ -6,11 +6,12 @@ export const dynamic = 'force-dynamic'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
+import { fromChileDateOnly, toChileDateString } from '@/lib/chileTime'
 
 type Plan = 'Mensual' | 'Anual'
 
 function toISO(d: Date) {
-  return d.toISOString().slice(0,10)
+  return toChileDateString(d)
 }
 function addMonths(date: Date, months: number) {
   const d = new Date(date); d.setMonth(d.getMonth() + months); return d
@@ -26,19 +27,19 @@ export default function AthleteNewPage() {
 
   const [plan, setPlan] = useState<Plan>('Mensual')
   const [start, setStart] = useState<string>(toISO(new Date()))
-  const [end, setEnd] = useState<string>(toISO(addMonths(new Date(), 1)))
+  const [end, setEnd] = useState<string>(toISO(addMonths(fromChileDateOnly(toISO(new Date())), 1)))
 
   const [busy, setBusy] = useState(false)
   const [msg, setMsg] = useState<string | null>(null)
 
   const onChangeStart = (v: string) => {
     setStart(v)
-    const base = v ? new Date(v) : new Date()
+    const base = v ? fromChileDateOnly(v) : new Date()
     setEnd(toISO(addMonths(base, plan === 'Anual' ? 12 : 1)))
   }
   const onChangePlan = (p: Plan) => {
     setPlan(p)
-    const base = start ? new Date(start) : new Date()
+    const base = start ? fromChileDateOnly(start) : new Date()
     setEnd(toISO(addMonths(base, p === 'Anual' ? 12 : 1)))
   }
 

--- a/app/api/access/validate/route.ts
+++ b/app/api/access/validate/route.ts
@@ -1,6 +1,7 @@
 // app/api/access/validate/route.ts
 import { NextRequest } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { startOfChileDay, toChileDateString, toChileISOString } from '@/lib/chileTime'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -28,9 +29,8 @@ function getServerClient() {
   return createClient(url, key, { auth: { persistSession: false } })
 }
 
-function todayUTCDateOnly(): Date {
-  const now = new Date()
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+function todayChileDateOnly(): Date {
+  return startOfChileDay(new Date())
 }
 
 export async function POST(req: NextRequest) {
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest) {
       return Response.json({ ok: false, error: 'cardUID requerido' }, { status: 400 })
     }
 
-    const today = todayUTCDateOnly()
+    const today = todayChileDateOnly()
 
     // 1) Buscar tarjeta activa
     const { data: card, error: cardErr } = await supabase
@@ -85,20 +85,27 @@ export async function POST(req: NextRequest) {
 
       const activeMems = (mems ?? []).filter(m => (m.status ?? 'active') === 'active')
       const covering = activeMems.find(m => {
-        const start = new Date(m.start_date)
-        const end = new Date(m.end_date)
+        if (!m.start_date || !m.end_date) return false
+        const start = startOfChileDay(m.start_date)
+        const end = startOfChileDay(m.end_date)
         return start <= today && today <= end
       })
 
       if (covering) {
         result = 'allowed'
-        membership = { plan: covering.plan ?? null, end_date: covering.end_date ?? null }
-      } else if (activeMems.some(m => new Date(m.end_date) < today)) {
+        membership = {
+          plan: covering.plan ?? null,
+          end_date: covering.end_date ? toChileDateString(covering.end_date) : null,
+        }
+      } else if (activeMems.some(m => m.end_date && startOfChileDay(m.end_date) < today)) {
         result = 'expired'
         const lastExpired = activeMems
-          .filter(m => new Date(m.end_date) < today)
+          .filter(m => m.end_date && startOfChileDay(m.end_date) < today)
           .sort((a, b) => (a.end_date < b.end_date ? 1 : -1))[0]
-        membership = { plan: lastExpired?.plan ?? null, end_date: lastExpired?.end_date ?? null }
+        membership = {
+          plan: lastExpired?.plan ?? null,
+          end_date: lastExpired?.end_date ? toChileDateString(lastExpired.end_date) : null,
+        }
       } else {
         result = 'denied'
       }
@@ -108,7 +115,7 @@ export async function POST(req: NextRequest) {
     const payload = {
       athlete_id: athlete?.id ?? null,
       card_uid: cleanedUID,
-      ts: new Date().toISOString(),
+      ts: toChileISOString(new Date()),
       result,
       note,
     }
@@ -127,7 +134,7 @@ export async function POST(req: NextRequest) {
     return Response.json({
       ok: result === 'allowed',
       access_id: inserted?.id ?? null,
-      ts: inserted?.ts ?? payload.ts,
+      ts: toChileISOString(inserted?.ts ?? payload.ts),
       result,
       uid: cleanedUID,
       athlete,

--- a/app/api/admin/reports/access/route.ts
+++ b/app/api/admin/reports/access/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { chileDateRange, startOfChileDay, toChileDateString, toChileISOString } from '@/lib/chileTime'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -38,12 +39,6 @@ function getServerClient() {
   return createClient(url, key, { auth: { persistSession: false } })
 }
 
-function parseDateRange(from?: string | null, to?: string | null) {
-  const isoFrom = from ? new Date(`${from}T00:00:00.000Z`).toISOString() : null
-  const isoTo = to ? new Date(`${to}T23:59:59.999Z`).toISOString() : null
-  return { isoFrom, isoTo }
-}
-
 // 👇 Mapeo de alias (UI) → labels reales del enum
 const STATUS_FILTERS: Record<string, string | string[]> = {
   ok: 'allowed',
@@ -65,7 +60,7 @@ export async function GET(req: NextRequest) {
     const from = url.searchParams.get('from')
     const to = url.searchParams.get('to')
     const limit = Math.min(Number(url.searchParams.get('limit')) || 5000, 50000)
-    const { isoFrom, isoTo } = parseDateRange(from, to)
+    const { isoFrom, isoTo } = chileDateRange(from, to)
 
     // 1) access_logs
     let q = supabase
@@ -134,24 +129,24 @@ export async function GET(req: NextRequest) {
       let plan_fin: string | null = null
 
       if (l.athlete_id && membershipsByAthlete[l.athlete_id]) {
-        const tsDate = new Date(l.ts)
-        const onlyDate = new Date(Date.UTC(tsDate.getUTCFullYear(), tsDate.getUTCMonth(), tsDate.getUTCDate()))
+        const onlyDate = startOfChileDay(l.ts)
         const found = membershipsByAthlete[l.athlete_id].find((m: any) => {
+          if (!m.start_date || !m.end_date) return false
           return (
             (m.status ?? 'active') === 'active' &&
-            new Date(m.start_date) <= onlyDate &&
-            onlyDate <= new Date(m.end_date)
+            startOfChileDay(m.start_date) <= onlyDate &&
+            onlyDate <= startOfChileDay(m.end_date)
           )
         })
         if (found) {
           plan_vigente = found.plan ?? null
-          plan_inicio = found.start_date ?? null
-          plan_fin = found.end_date ?? null
+          plan_inicio = found.start_date ? toChileDateString(found.start_date) : null
+          plan_fin = found.end_date ? toChileDateString(found.end_date) : null
         }
       }
 
       return {
-        fecha: l.ts,
+        fecha: toChileISOString(l.ts),
         socio: ath?.name ?? null,
         email: ath?.email ?? null,
         phone: ath?.phone ?? null,

--- a/app/api/admin/reports/summary/route.ts
+++ b/app/api/admin/reports/summary/route.ts
@@ -1,6 +1,7 @@
 // app/api/admin/reports/summary/route.ts
 import { NextRequest } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { chileDateRange, toChileDateString } from '@/lib/chileTime'
 
 type AccessStatus = 'allowed' | 'denied' | 'expired' | 'unknown_card'
 
@@ -35,16 +36,8 @@ function getServerClient() {
 }
 
 function ym(d: string | Date) {
-  const dt = new Date(d)
-  const y = dt.getUTCFullYear()
-  const m = String(dt.getUTCMonth() + 1).padStart(2, '0')
-  return `${y}-${m}`
-}
-
-function parseDateRange(from?: string | null, to?: string | null) {
-  const isoFrom = from ? new Date(`${from}T00:00:00.000Z`).toISOString() : null
-  const isoTo = to ? new Date(`${to}T23:59:59.999Z`).toISOString() : null
-  return { isoFrom, isoTo }
+  const date = toChileDateString(d)
+  return date.slice(0, 7)
 }
 
 // GET /api/admin/reports/summary?from=YYYY-MM-DD&to=YYYY-MM-DD
@@ -54,7 +47,7 @@ export async function GET(req: NextRequest) {
     const url = new URL(req.url)
     const from = url.searchParams.get('from')
     const to = url.searchParams.get('to')
-    const { isoFrom, isoTo } = parseDateRange(from, to)
+    const { isoFrom, isoTo } = chileDateRange(from, to)
 
     // Access logs
     let qa = supabase.from('access_logs').select('ts, result')

--- a/app/kiosk/page.tsx
+++ b/app/kiosk/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
+import { formatChileDateTime } from '@/lib/chileTime'
 
 type AccessResult = {
   name: string
@@ -11,10 +12,13 @@ type AccessResult = {
 
 function formatDate(dateStr?: string) {
   if (!dateStr) return ''
-  return new Date(dateStr).toLocaleDateString('es-ES', {
+  return formatChileDateTime(dateStr, {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
+    hour: undefined,
+    minute: undefined,
+    second: undefined,
   })
 }
 

--- a/lib/chileTime.ts
+++ b/lib/chileTime.ts
@@ -1,0 +1,133 @@
+const CHILE_TZ = 'America/Santiago'
+
+type DateInput = Date | string | number
+
+function toDate(input: DateInput): Date {
+  if (input instanceof Date) return new Date(input.getTime())
+  if (typeof input === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(input)) {
+    return fromChileDateOnly(input)
+  }
+  return new Date(input)
+}
+
+const zonedFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: CHILE_TZ,
+  hourCycle: 'h23',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  fractionalSecondDigits: 3,
+})
+
+type ZonedParts = {
+  year: string
+  month: string
+  day: string
+  hour: string
+  minute: string
+  second: string
+  fraction: string
+}
+
+function getZonedParts(date: Date): ZonedParts {
+  const map: Partial<Record<string, string>> = {}
+  for (const part of zonedFormatter.formatToParts(date)) {
+    if (part.type === 'literal') continue
+    map[part.type] = part.value
+  }
+  return {
+    year: map.year ?? '1970',
+    month: map.month ?? '01',
+    day: map.day ?? '01',
+    hour: map.hour ?? '00',
+    minute: map.minute ?? '00',
+    second: map.second ?? '00',
+    fraction: map.fractionalSecond ?? '000',
+  }
+}
+
+function getOffsetMinutes(date: Date): number {
+  const parts = getZonedParts(date)
+  const asUTC = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour),
+    Number(parts.minute),
+    Number(parts.second),
+    Number(parts.fraction),
+  )
+  return (asUTC - date.getTime()) / 60000
+}
+
+function offsetToString(offsetMinutes: number): string {
+  const sign = offsetMinutes <= 0 ? '-' : '+'
+  const absolute = Math.abs(offsetMinutes)
+  const hours = String(Math.floor(absolute / 60)).padStart(2, '0')
+  const minutes = String(absolute % 60).padStart(2, '0')
+  return `${sign}${hours}:${minutes}`
+}
+
+export function toChileISOString(input: DateInput): string {
+  const date = toDate(input)
+  const parts = getZonedParts(date)
+  const offset = offsetToString(getOffsetMinutes(date))
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}.${parts.fraction}${offset}`
+}
+
+export function toChileDateString(input: DateInput): string {
+  return toChileISOString(input).slice(0, 10)
+}
+
+export function startOfChileDay(input: DateInput): Date {
+  const isoDate = toChileDateString(input)
+  return fromChileDateOnly(isoDate)
+}
+
+export function endOfChileDay(input: DateInput): Date {
+  const start = startOfChileDay(input)
+  return new Date(start.getTime() + 24 * 60 * 60 * 1000 - 1)
+}
+
+export function fromChileDateOnly(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map((v) => Number(v))
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+    throw new Error(`Invalid Chile date string: ${dateStr}`)
+  }
+  // Use midday to obtain the correct offset for that calendar day and avoid DST switch issues.
+  const reference = new Date(Date.UTC(year, month - 1, day, 12, 0, 0))
+  const offsetMinutes = getOffsetMinutes(reference)
+  const utcMillis = Date.UTC(year, month - 1, day, 0, 0, 0) - offsetMinutes * 60 * 1000
+  return new Date(utcMillis)
+}
+
+export function chileDateRange(from?: string | null, to?: string | null) {
+  const isoFrom = from ? fromChileDateOnly(from).toISOString() : null
+  const isoTo = to ? endOfChileDay(to).toISOString() : null
+  return { isoFrom, isoTo }
+}
+
+export function formatChileDateTime(input: DateInput, options?: Intl.DateTimeFormatOptions) {
+  const base: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }
+  const final: Intl.DateTimeFormatOptions = { ...base, ...(options ?? {}) }
+  for (const key of Object.keys(final)) {
+    if ((final as any)[key] === undefined) delete (final as any)[key]
+  }
+  const formatter = new Intl.DateTimeFormat('es-CL', {
+    timeZone: CHILE_TZ,
+    hourCycle: 'h23',
+    ...final,
+  })
+  return formatter.format(toDate(input))
+}
+


### PR DESCRIPTION
## Summary
- add a shared Chile timezone helper to normalize conversions, formatting, and date-range calculations
- update access validation and admin report endpoints to store and export timestamps using UTC-3 semantics
- adjust admin and kiosk interfaces so displayed and defaulted dates align with Chilean local time

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c41a45b0832e9460161d844e45d9