### PR TITLE
Add admin time configuration and apply offset overrides

### DIFF
--- a/app/(site)/admin/athletes/[id]/page.tsx
+++ b/app/(site)/admin/athletes/[id]/page.tsx
@@ -5,6 +5,7 @@ export const dynamic = 'force-dynamic'
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
+import { formatChileDateTime, fromChileDateOnly, toChileDateString } from '@/lib/chileTime'
 
 type Athlete = {
   id: string
@@ -26,7 +27,7 @@ type AccessLog = {
 }
 
 function fmtDate(d: Date) {
-  return d.toISOString().slice(0, 10)
+  return toChileDateString(d)
 }
 function addMonths(date: Date, months: number) {
   const d = new Date(date)
@@ -110,7 +111,7 @@ export default function AthleteEditPage() {
     setCurrentEnd((mem as any)?.end_date ?? '')
     setMemPlan(planFromMem)
     setMemStart(today)
-    const base = new Date(today)
+    const base = fromChileDateOnly(today)
     setMemEnd(fmtDate(planFromMem === 'Anual' ? addMonths(base, 12) : addMonths(base, 1)))
 
     // 4) Historial de accesos (últimos 20)
@@ -134,7 +135,7 @@ export default function AthleteEditPage() {
   // Recalcular fin al cambiar plan o start (para la NUEVA membresía)
   useEffect(() => {
     if (!memStart) return
-    const base = new Date(memStart)
+    const base = fromChileDateOnly(memStart)
     const end = memPlan === 'Anual' ? addMonths(base, 12) : addMonths(base, 1)
     setMemEnd(fmtDate(end))
   }, [memPlan, memStart])
@@ -339,7 +340,10 @@ export default function AthleteEditPage() {
 
         {/* Actual vigente (solo lectura) */}
         <div className="text-sm text-gray-700">
-          <div>Vigente actual: {currentStart ? `${new Date(currentStart).toLocaleDateString()} → ${new Date(currentEnd).toLocaleDateString()}` : '—'}</div>
+          <div>
+            Vigente actual:{' '}
+            {currentStart ? `${toChileDateString(currentStart)} → ${toChileDateString(currentEnd)}` : '—'}
+          </div>
         </div>
 
         {/* Nueva membresía */}
@@ -381,7 +385,7 @@ export default function AthleteEditPage() {
           <button
             disabled={busy}
             onClick={() => {
-              const base = memStart ? new Date(memStart) : new Date()
+              const base = memStart ? fromChileDateOnly(memStart) : new Date()
               const end = memPlan === 'Anual' ? addMonths(base, 12) : addMonths(base, 1)
               setMemEnd(fmtDate(end))
             }}
@@ -411,7 +415,7 @@ export default function AthleteEditPage() {
               <tbody>
                 {access.map((l) => (
                   <tr key={l.id} className="border-t">
-                    <td className="px-3 py-2">{new Date(l.ts).toLocaleString()}</td>
+                    <td className="px-3 py-2">{formatChileDateTime(l.ts)}</td>
                     <td className="px-3 py-2">{l.result}</td>
                     <td className="px-3 py-2">{l.card_uid ?? '—'}</td>
                     <td className="px-3 py-2">{l.note ?? '—'}</td>

--- a/app/(site)/admin/athletes/new/page.tsx
+++ b/app/(site)/admin/athletes/new/page.tsx
@@ -6,11 +6,12 @@ export const dynamic = 'force-dynamic'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
+import { fromChileDateOnly, toChileDateString } from '@/lib/chileTime'
 
 type Plan = 'Mensual' | 'Anual'
 
 function toISO(d: Date) {
-  return d.toISOString().slice(0,10)
+  return toChileDateString(d)
 }
 function addMonths(date: Date, months: number) {
   const d = new Date(date); d.setMonth(d.getMonth() + months); return d
@@ -26,19 +27,19 @@ export default function AthleteNewPage() {
 
   const [plan, setPlan] = useState<Plan>('Mensual')
   const [start, setStart] = useState<string>(toISO(new Date()))
-  const [end, setEnd] = useState<string>(toISO(addMonths(new Date(), 1)))
+  const [end, setEnd] = useState<string>(toISO(addMonths(fromChileDateOnly(toISO(new Date())), 1)))
 
   const [busy, setBusy] = useState(false)
   const [msg, setMsg] = useState<string | null>(null)
 
   const onChangeStart = (v: string) => {
     setStart(v)
-    const base = v ? new Date(v) : new Date()
+    const base = v ? fromChileDateOnly(v) : new Date()
     setEnd(toISO(addMonths(base, plan === 'Anual' ? 12 : 1)))
   }
   const onChangePlan = (p: Plan) => {
     setPlan(p)
-    const base = start ? new Date(start) : new Date()
+    const base = start ? fromChileDateOnly(start) : new Date()
     setEnd(toISO(addMonths(base, p === 'Anual' ? 12 : 1)))
   }
 

--- a/app/(site)/admin/page.tsx
+++ b/app/(site)/admin/page.tsx
@@ -51,6 +51,11 @@ export default function AdminHome() {
           title="Reportes"
           subtitle="Descarga de accesos, membresías y más"
         />
+        <Tile
+          href="/admin/settings"
+          title="Configuración"
+          subtitle="Ajusta horarios y preferencias generales"
+        />
       </div>
     </main>
   )

--- a/app/(site)/admin/settings/page.tsx
+++ b/app/(site)/admin/settings/page.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+
+import { formatChileDateTime } from '@/lib/chileTime'
+import { setChileTimeOverride } from '@/lib/timeSettings'
+
+type SettingsResponse = {
+  ok: boolean
+  settings?: {
+    timezoneOffsetMinutes: number | null
+    updatedAt: string | null
+  }
+  error?: string
+}
+
+type OffsetOption = {
+  label: string
+  description: string
+  value: number | null
+}
+
+const OPTIONS: OffsetOption[] = [
+  {
+    label: 'Automático (America/Santiago)',
+    description:
+      'Usa las reglas oficiales de zona horaria. Útil si deseas delegar los cambios de horario de verano/invierno.',
+    value: null,
+  },
+  {
+    label: 'Horario de verano (UTC-3)',
+    description: 'Chile continental entre septiembre y abril. Equivalente a UTC-03:00.',
+    value: -180,
+  },
+  {
+    label: 'Horario de invierno (UTC-4)',
+    description: 'Chile continental entre abril y septiembre. Equivalente a UTC-04:00.',
+    value: -240,
+  },
+]
+
+function valueToInput(v: number | null) {
+  return v === null ? 'null' : String(v)
+}
+
+function parseInputValue(v: string): number | null {
+  if (v === 'null') return null
+  const num = Number(v)
+  return Number.isFinite(num) ? Math.trunc(num) : null
+}
+
+function formatOffsetLabel(value: number | null) {
+  if (value === null) return 'Automático'
+  const absolute = Math.abs(value)
+  const sign = value <= 0 ? '-' : '+'
+  const hours = String(Math.floor(absolute / 60)).padStart(2, '0')
+  const minutes = String(absolute % 60).padStart(2, '0')
+  return `UTC${sign}${hours}:${minutes}`
+}
+
+export default function AdminSettingsPage() {
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [offset, setOffset] = useState<number | null>(null)
+  const [updatedAt, setUpdatedAt] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch('/api/admin/settings', { cache: 'no-store' })
+        const data: SettingsResponse = await res.json()
+        if (!data.ok || !data.settings) {
+          throw new Error(data.error || 'No se pudieron obtener las configuraciones')
+        }
+        setOffset(data.settings.timezoneOffsetMinutes)
+        setUpdatedAt(data.settings.updatedAt)
+        setChileTimeOverride(data.settings.timezoneOffsetMinutes)
+      } catch (err: any) {
+        console.error('No se pudo cargar la configuración', err)
+        setError(err?.message || 'No se pudo cargar la configuración')
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  const preview = useMemo(() => formatOffsetLabel(offset), [offset])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    setMessage(null)
+    setError(null)
+    try {
+      const res = await fetch('/api/admin/settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ timezoneOffsetMinutes: offset }),
+      })
+      const data: SettingsResponse = await res.json()
+      if (!data.ok || !data.settings) {
+        throw new Error(data.error || 'No se pudieron guardar los cambios')
+      }
+      setOffset(data.settings.timezoneOffsetMinutes)
+      setUpdatedAt(data.settings.updatedAt)
+      setChileTimeOverride(data.settings.timezoneOffsetMinutes)
+      setMessage('Configuración guardada correctamente.')
+    } catch (err: any) {
+      console.error('No se pudo guardar la configuración', err)
+      setError(err?.message || 'No se pudo guardar la configuración')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-6">
+      <Link href="/admin" className="text-sm underline">
+        ← Volver al panel
+      </Link>
+      <h1 className="text-2xl font-bold">Configuración general</h1>
+
+      <section className="border rounded-xl bg-white p-6 space-y-4">
+        <header className="space-y-1">
+          <h2 className="text-xl font-semibold">Zona horaria de Chile</h2>
+          <p className="text-sm text-gray-600">
+            Ajusta el desfase utilizado para reportes, validaciones de acceso y horarios mostrados en la plataforma.
+            Recuerda actualizar este valor cuando el país cambie entre horario de verano e invierno.
+          </p>
+        </header>
+
+        {loading ? (
+          <p className="text-sm">Cargando configuración…</p>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <fieldset className="space-y-3">
+              <legend className="text-sm font-semibold">Selecciona el desfase actual</legend>
+              {OPTIONS.map((opt) => {
+                const id = `offset-${valueToInput(opt.value)}`
+                return (
+                  <label key={id} htmlFor={id} className="flex gap-3 rounded-lg border p-3 hover:border-gray-400 transition">
+                    <input
+                      id={id}
+                      type="radio"
+                      name="timezone-offset"
+                      value={valueToInput(opt.value)}
+                      checked={valueToInput(offset) === valueToInput(opt.value)}
+                      onChange={(event) => setOffset(parseInputValue(event.target.value))}
+                      className="mt-1"
+                    />
+                    <div>
+                      <div className="font-medium">{opt.label}</div>
+                      <p className="text-sm text-gray-600">{opt.description}</p>
+                    </div>
+                  </label>
+                )
+              })}
+            </fieldset>
+
+            <div className="rounded-lg bg-gray-50 p-3 text-sm">
+              Desfase activo: <span className="font-semibold">{preview}</span>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="submit"
+                disabled={saving}
+                className="px-4 py-2 rounded-xl border shadow bg-white disabled:opacity-60"
+              >
+                {saving ? 'Guardando…' : 'Guardar cambios'}
+              </button>
+              {message && <span className="text-sm text-green-700">{message}</span>}
+              {error && <span className="text-sm text-red-600">{error}</span>}
+            </div>
+
+            {updatedAt && (
+              <p className="text-xs text-gray-500">
+                Última actualización:{' '}
+                {formatChileDateTime(updatedAt, {
+                  dateStyle: 'short',
+                  timeStyle: 'short',
+                })}
+              </p>
+            )}
+          </form>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/app/api/admin/reports/memberships/route.ts
+++ b/app/api/admin/reports/memberships/route.ts
@@ -1,6 +1,13 @@
 // app/api/admin/reports/memberships/route.ts
 import { NextRequest } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import {
+  chileDateRange,
+  formatChileDateTime,
+  startOfChileDay,
+  toChileDateString,
+} from '@/lib/chileTime'
+import { loadAndApplyAppSettings } from '@/lib/appSettings.server'
 
 type Row = {
   socio: string
@@ -35,22 +42,17 @@ function getServerClient() {
   return createClient(url, key, { auth: { persistSession: false } })
 }
 
-function parseDateRange(from?: string | null, to?: string | null) {
-  const isoFrom = from ? new Date(`${from}T00:00:00.000Z`).toISOString() : null
-  const isoTo = to ? new Date(`${to}T23:59:59.999Z`).toISOString() : null
-  return { isoFrom, isoTo }
-}
-
 // GET /api/admin/reports/memberships?from=YYYY-MM-DD&to=YYYY-MM-DD&date_field=created_at|start_date|end_date&limit=10000
 export async function GET(req: NextRequest) {
   try {
+    await loadAndApplyAppSettings()
     const supabase = getServerClient()
     const url = new URL(req.url)
     const from = url.searchParams.get('from')
     const to = url.searchParams.get('to')
     const dateField = (url.searchParams.get('date_field') ?? 'created_at') as 'created_at' | 'start_date' | 'end_date'
     const limit = Math.min(Number(url.searchParams.get('limit')) || 10000, 50000)
-    const { isoFrom, isoTo } = parseDateRange(from, to)
+    const { isoFrom, isoTo } = chileDateRange(from, to)
 
     // Traer memberships + nombre del atleta
     let q = supabase
@@ -83,11 +85,15 @@ export async function GET(req: NextRequest) {
         if (!prev) {
           tipo = 'Nueva'
         } else if (m.plan === prev.plan) {
-          const prevEnd = new Date(prev.end_date).getTime()
-          const mStart = new Date(m.start_date).getTime()
-          // contiguo (1 día)
-          if (mStart === prevEnd + 24 * 60 * 60 * 1000) tipo = 'Renovación'
-          else tipo = 'Cambio de plan' // mismo plan pero con lag → lo tratamos como “cambio/otro”
+          if (!prev.end_date || !m.start_date) {
+            tipo = 'Cambio de plan'
+          } else {
+            const prevEnd = startOfChileDay(prev.end_date).getTime()
+            const mStart = startOfChileDay(m.start_date).getTime()
+            // contiguo (1 día)
+            if (mStart === prevEnd + 24 * 60 * 60 * 1000) tipo = 'Renovación'
+            else tipo = 'Cambio de plan' // mismo plan pero con lag → lo tratamos como “cambio/otro”
+          }
         } else {
           tipo = 'Cambio de plan'
         }
@@ -98,12 +104,12 @@ export async function GET(req: NextRequest) {
           socio: m.athletes?.name ?? '[sin nombre]',
           plan_nuevo: m.plan,
           plan_anterior: prev?.plan ?? null,
-          start_date: m.start_date,
-          end_date: m.end_date,
+          start_date: m.start_date ? toChileDateString(m.start_date) : '',
+          end_date: m.end_date ? toChileDateString(m.end_date) : '',
           status_registro: m.status ?? 'active',
           tipo_movimiento: tipo,
           estado_actual,
-          created_at: m.created_at ?? null,
+          created_at: m.created_at ? formatChileDateTime(m.created_at) : null,
         })
         prev = m
       }

--- a/app/api/admin/reports/summary/route.ts
+++ b/app/api/admin/reports/summary/route.ts
@@ -1,6 +1,8 @@
 // app/api/admin/reports/summary/route.ts
 import { NextRequest } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { chileDateRange, toChileDateString } from '@/lib/chileTime'
+import { loadAndApplyAppSettings } from '@/lib/appSettings.server'
 
 type AccessStatus = 'allowed' | 'denied' | 'expired' | 'unknown_card'
 
@@ -35,26 +37,19 @@ function getServerClient() {
 }
 
 function ym(d: string | Date) {
-  const dt = new Date(d)
-  const y = dt.getUTCFullYear()
-  const m = String(dt.getUTCMonth() + 1).padStart(2, '0')
-  return `${y}-${m}`
-}
-
-function parseDateRange(from?: string | null, to?: string | null) {
-  const isoFrom = from ? new Date(`${from}T00:00:00.000Z`).toISOString() : null
-  const isoTo = to ? new Date(`${to}T23:59:59.999Z`).toISOString() : null
-  return { isoFrom, isoTo }
+  const date = toChileDateString(d)
+  return date.slice(0, 7)
 }
 
 // GET /api/admin/reports/summary?from=YYYY-MM-DD&to=YYYY-MM-DD
 export async function GET(req: NextRequest) {
   try {
+    await loadAndApplyAppSettings()
     const supabase = getServerClient()
     const url = new URL(req.url)
     const from = url.searchParams.get('from')
     const to = url.searchParams.get('to')
-    const { isoFrom, isoTo } = parseDateRange(from, to)
+    const { isoFrom, isoTo } = chileDateRange(from, to)
 
     // Access logs
     let qa = supabase.from('access_logs').select('ts, result')

--- a/app/api/admin/settings/route.ts
+++ b/app/api/admin/settings/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from 'next/server'
+
+import { loadAndApplyAppSettings, updateAppSettings } from '@/lib/appSettings.server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    const settings = await loadAndApplyAppSettings()
+    return Response.json({ ok: true, settings })
+  } catch (error: any) {
+    const message = error?.message ?? 'No se pudieron obtener las configuraciones.'
+    return Response.json({ ok: false, error: message }, { status: 500 })
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    const body = await req.json()
+    const raw = body?.timezoneOffsetMinutes
+    let timezoneOffsetMinutes: number | null
+    if (raw === null || raw === undefined) {
+      timezoneOffsetMinutes = null
+    } else if (typeof raw === 'number' && Number.isFinite(raw)) {
+      timezoneOffsetMinutes = Math.trunc(raw)
+    } else {
+      throw new Error('timezoneOffsetMinutes debe ser un número o null')
+    }
+    const settings = await updateAppSettings({ timezoneOffsetMinutes })
+    return Response.json({ ok: true, settings })
+  } catch (error: any) {
+    const message = error?.message ?? 'No se pudieron actualizar las configuraciones.'
+    return Response.json({ ok: false, error: message }, { status: 500 })
+  }
+}

--- a/app/kiosk/page.tsx
+++ b/app/kiosk/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
+import { formatChileDateTime } from '@/lib/chileTime'
 
 type AccessResult = {
   name: string
@@ -11,10 +12,13 @@ type AccessResult = {
 
 function formatDate(dateStr?: string) {
   if (!dateStr) return ''
-  return new Date(dateStr).toLocaleDateString('es-ES', {
+  return formatChileDateTime(dateStr, {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
+    hour: undefined,
+    minute: undefined,
+    second: undefined,
   })
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,19 +3,34 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
+import { loadAndApplyAppSettings } from '@/lib/appSettings.server'
+
 export const metadata: Metadata = {
   title: "FitnessClub Grulla Blanca",
   description: "App con métricas de rendimiento (Vercel Speed Insights)",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  let offset: number | null = null
+  try {
+    const settings = await loadAndApplyAppSettings()
+    offset = settings.timezoneOffsetMinutes ?? null
+  } catch (err) {
+    console.error('Failed to load app settings', err)
+    offset = null
+  }
+  const offsetScript = `window.__CHILE_TIME_OFFSET__ = ${offset ?? 'null'};`
   return (
     <html lang="es">
       <body>
+        <script
+          id="chile-time-offset"
+          dangerouslySetInnerHTML={{ __html: offsetScript }}
+        />
         {children}
         {/* 👇 Este componente envía las métricas a Vercel */}
         <SpeedInsights />

--- a/lib/appSettings.server.ts
+++ b/lib/appSettings.server.ts
@@ -1,0 +1,88 @@
+import 'server-only'
+
+import { getServiceRoleClient } from '@/lib/supabase/service-role'
+import { setChileTimeOverride } from '@/lib/timeSettings'
+
+export type AppSettings = {
+  timezoneOffsetMinutes: number | null
+  updatedAt: string | null
+}
+
+const SETTINGS_KEY = 'general'
+const DEFAULT_SETTINGS: AppSettings = {
+  timezoneOffsetMinutes: -180,
+  updatedAt: null,
+}
+
+let cached: AppSettings | null = null
+let cachedAt = 0
+const CACHE_WINDOW_MS = 30 * 1000
+
+function normalizeSettings(row: { value?: unknown; updated_at?: string | null } | null): AppSettings {
+  const base = { ...DEFAULT_SETTINGS }
+  if (row?.value && typeof row.value === 'object') {
+    const value = row.value as Record<string, unknown>
+    if (typeof value.timezoneOffsetMinutes === 'number' && Number.isFinite(value.timezoneOffsetMinutes)) {
+      base.timezoneOffsetMinutes = Math.trunc(value.timezoneOffsetMinutes)
+    } else if (value.timezoneOffsetMinutes === null) {
+      base.timezoneOffsetMinutes = null
+    }
+  }
+  if (row?.updated_at) {
+    base.updatedAt = row.updated_at
+  }
+  return base
+}
+
+async function fetchSettings(): Promise<AppSettings> {
+  const supabase = getServiceRoleClient()
+  const { data, error } = await supabase
+    .from('app_settings')
+    .select('value, updated_at')
+    .eq('key', SETTINGS_KEY)
+    .maybeSingle()
+  if (error) throw error
+  const next = normalizeSettings(data ?? null)
+  return next
+}
+
+function apply(settings: AppSettings) {
+  setChileTimeOverride(settings.timezoneOffsetMinutes)
+}
+
+export async function loadAndApplyAppSettings(options?: { force?: boolean }): Promise<AppSettings> {
+  const force = options?.force ?? false
+  if (!force && cached && Date.now() - cachedAt < CACHE_WINDOW_MS) {
+    apply(cached)
+    return cached
+  }
+  const settings = await fetchSettings()
+  cached = settings
+  cachedAt = Date.now()
+  apply(settings)
+  return settings
+}
+
+export async function updateAppSettings(patch: Partial<AppSettings>): Promise<AppSettings> {
+  const current = await loadAndApplyAppSettings({ force: true })
+  const next: AppSettings = {
+    ...current,
+    ...patch,
+  }
+  if (typeof next.timezoneOffsetMinutes === 'number' && !Number.isFinite(next.timezoneOffsetMinutes)) {
+    next.timezoneOffsetMinutes = null
+  }
+  if (typeof next.timezoneOffsetMinutes === 'number') {
+    next.timezoneOffsetMinutes = Math.trunc(next.timezoneOffsetMinutes)
+  }
+  const supabase = getServiceRoleClient()
+  const nowIso = new Date().toISOString()
+  const { error } = await supabase
+    .from('app_settings')
+    .upsert({ key: SETTINGS_KEY, value: next, updated_at: nowIso })
+  if (error) throw error
+  cached = { ...next, updatedAt: nowIso }
+  cachedAt = Date.now()
+  apply(cached)
+  return cached
+}

--- a/lib/chileTime.ts
+++ b/lib/chileTime.ts
@@ -1,0 +1,158 @@
+import { getChileTimeOverride } from '@/lib/timeSettings'
+
+const CHILE_TZ = 'America/Santiago'
+
+type DateInput = Date | string | number
+
+function toDate(input: DateInput): Date {
+  if (input instanceof Date) return new Date(input.getTime())
+  if (typeof input === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(input)) {
+    return fromChileDateOnly(input)
+  }
+  return new Date(input)
+}
+
+const zonedFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: CHILE_TZ,
+  hourCycle: 'h23',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  fractionalSecondDigits: 3,
+})
+
+type ZonedParts = {
+  year: string
+  month: string
+  day: string
+  hour: string
+  minute: string
+  second: string
+  fraction: string
+}
+
+function getZonedParts(date: Date): ZonedParts {
+  const override = getChileTimeOverride()
+  if (typeof override === 'number') {
+    const shifted = new Date(date.getTime() + override * 60 * 1000)
+    return {
+      year: String(shifted.getUTCFullYear()).padStart(4, '0'),
+      month: String(shifted.getUTCMonth() + 1).padStart(2, '0'),
+      day: String(shifted.getUTCDate()).padStart(2, '0'),
+      hour: String(shifted.getUTCHours()).padStart(2, '0'),
+      minute: String(shifted.getUTCMinutes()).padStart(2, '0'),
+      second: String(shifted.getUTCSeconds()).padStart(2, '0'),
+      fraction: String(shifted.getUTCMilliseconds()).padStart(3, '0'),
+    }
+  }
+  const map: Partial<Record<string, string>> = {}
+  for (const part of zonedFormatter.formatToParts(date)) {
+    if (part.type === 'literal') continue
+    map[part.type] = part.value
+  }
+  return {
+    year: map.year ?? '1970',
+    month: map.month ?? '01',
+    day: map.day ?? '01',
+    hour: map.hour ?? '00',
+    minute: map.minute ?? '00',
+    second: map.second ?? '00',
+    fraction: map.fractionalSecond ?? '000',
+  }
+}
+
+function getOffsetMinutes(date: Date): number {
+  const override = getChileTimeOverride()
+  if (typeof override === 'number') {
+    return override
+  }
+  const parts = getZonedParts(date)
+  const asUTC = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour),
+    Number(parts.minute),
+    Number(parts.second),
+    Number(parts.fraction),
+  )
+  return (asUTC - date.getTime()) / 60000
+}
+
+function offsetToString(offsetMinutes: number): string {
+  const sign = offsetMinutes <= 0 ? '-' : '+'
+  const absolute = Math.abs(offsetMinutes)
+  const hours = String(Math.floor(absolute / 60)).padStart(2, '0')
+  const minutes = String(absolute % 60).padStart(2, '0')
+  return `${sign}${hours}:${minutes}`
+}
+
+export function toChileISOString(input: DateInput): string {
+  const date = toDate(input)
+  const parts = getZonedParts(date)
+  const offset = offsetToString(getOffsetMinutes(date))
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}.${parts.fraction}${offset}`
+}
+
+export function toChileDateString(input: DateInput): string {
+  return toChileISOString(input).slice(0, 10)
+}
+
+export function startOfChileDay(input: DateInput): Date {
+  const isoDate = toChileDateString(input)
+  return fromChileDateOnly(isoDate)
+}
+
+export function endOfChileDay(input: DateInput): Date {
+  const start = startOfChileDay(input)
+  return new Date(start.getTime() + 24 * 60 * 60 * 1000 - 1)
+}
+
+export function fromChileDateOnly(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map((v) => Number(v))
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+    throw new Error(`Invalid Chile date string: ${dateStr}`)
+  }
+  // Use midday to obtain the correct offset for that calendar day and avoid DST switch issues.
+  const reference = new Date(Date.UTC(year, month - 1, day, 12, 0, 0))
+  const offsetMinutes = getOffsetMinutes(reference)
+  const utcMillis = Date.UTC(year, month - 1, day, 0, 0, 0) - offsetMinutes * 60 * 1000
+  return new Date(utcMillis)
+}
+
+export function chileDateRange(from?: string | null, to?: string | null) {
+  const isoFrom = from ? fromChileDateOnly(from).toISOString() : null
+  const isoTo = to ? endOfChileDay(to).toISOString() : null
+  return { isoFrom, isoTo }
+}
+
+export function formatChileDateTime(input: DateInput, options?: Intl.DateTimeFormatOptions) {
+  const base: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }
+  const final: Intl.DateTimeFormatOptions = { ...base, ...(options ?? {}) }
+  for (const key of Object.keys(final)) {
+    if ((final as any)[key] === undefined) delete (final as any)[key]
+  }
+  const override = getChileTimeOverride()
+  const formatter = new Intl.DateTimeFormat('es-CL', {
+    timeZone: override === null ? CHILE_TZ : 'UTC',
+    hourCycle: 'h23',
+    ...final,
+  })
+  const date = toDate(input)
+  if (typeof override === 'number') {
+    const shifted = new Date(date.getTime() + override * 60 * 1000)
+    return formatter.format(shifted)
+  }
+  return formatter.format(date)
+}
+

--- a/lib/timeSettings.ts
+++ b/lib/timeSettings.ts
@@ -1,0 +1,41 @@
+const GLOBAL_KEY = Symbol.for('fitnessclub.chileTimeConfig')
+
+type ChileTimeStore = {
+  offsetMinutes: number | null
+}
+
+function getStore(): ChileTimeStore {
+  const globalAny = globalThis as Record<PropertyKey, unknown>
+  if (!globalAny[GLOBAL_KEY]) {
+    globalAny[GLOBAL_KEY] = { offsetMinutes: null } satisfies ChileTimeStore
+  }
+  return globalAny[GLOBAL_KEY] as ChileTimeStore
+}
+
+export function getChileTimeOverride(): number | null {
+  if (typeof window !== 'undefined') {
+    const win = window as Record<string, unknown>
+    if ('__CHILE_TIME_OFFSET__' in win) {
+      const raw = win.__CHILE_TIME_OFFSET__
+      if (typeof raw === 'number' && Number.isFinite(raw)) {
+        const rounded = Math.trunc(raw)
+        setChileTimeOverride(rounded)
+      } else if (raw === null) {
+        setChileTimeOverride(null)
+      }
+    }
+  }
+  return getStore().offsetMinutes
+}
+
+export function setChileTimeOverride(offsetMinutes: number | null) {
+  const store = getStore()
+  if (typeof offsetMinutes === 'number' && Number.isFinite(offsetMinutes)) {
+    store.offsetMinutes = Math.trunc(offsetMinutes)
+  } else {
+    store.offsetMinutes = null
+  }
+  if (typeof window !== 'undefined') {
+    ;(window as Record<string, unknown>).__CHILE_TIME_OFFSET__ = store.offsetMinutes
+  }
+}

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -61,6 +61,12 @@ create table if not exists public.routine_assignments (
   notes text
 );
 
+create table if not exists public.app_settings (
+  key text primary key,
+  value jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
 -- RLS
 alter table public.routines enable row level security;
 create policy if not exists "Public can read public routines"
@@ -72,6 +78,7 @@ alter table public.athletes enable row level security;
 alter table public.cards enable row level security;
 alter table public.memberships enable row level security;
 alter table public.access_logs enable row level security;
+alter table public.app_settings enable row level security;
 
 create policy if not exists "Admins only athletes"
 on public.athletes for all to authenticated using (true) with check (true);
@@ -84,3 +91,6 @@ on public.memberships for all to authenticated using (true) with check (true);
 
 create policy if not exists "Admins only access_logs"
 on public.access_logs for all to authenticated using (true) with check (true);
+
+create policy if not exists "Admins only app settings"
+on public.app_settings for all to authenticated using (true) with check (true);


### PR DESCRIPTION
## Summary
- add an `app_settings` table and server helper to persist timezone offset overrides
- load the configured offset in layout and API routes so validations and reports honor the manual Chile time setting
- expose a new admin configuration page to toggle UTC-3/UTC-4 (or automatic) and link it from the admin home

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c41a45b0832e9460161d844e45d9